### PR TITLE
disable key based register and auth endpoints

### DIFF
--- a/MorphicServer.Tests/AuthEndpointTests.cs
+++ b/MorphicServer.Tests/AuthEndpointTests.cs
@@ -109,6 +109,16 @@ namespace MorphicServer.Tests
         }
 
         [Fact]
+        public async Task TestKeyDisabled()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/key");
+            request.Content = new StringContent(@"{""key"": ""testkey""}", Encoding.UTF8, JsonMediaType);
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        // Disabled until we re-enabled the endpoint
+        // [Fact]
         public async Task TestKey()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/key");

--- a/MorphicServer.Tests/EndpointTests.cs
+++ b/MorphicServer.Tests/EndpointTests.cs
@@ -86,10 +86,11 @@ namespace MorphicServer.Tests
         {
             ++TestUserCount;
             var content = new Dictionary<string, object>();
-            content.Add("key", $"testkey{TestUserCount}");
+            content.Add("username", $"user{TestUserCount}");
+            content.Add("password", "thisisatestpassword");
             content.Add("first_name", firstName);
             content.Add("last_name", lastName);
-            var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/key");
+            var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/username");
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             var response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/MorphicServer.Tests/RegisterEndpointTests.cs
+++ b/MorphicServer.Tests/RegisterEndpointTests.cs
@@ -160,6 +160,16 @@ namespace MorphicServer.Tests
         }
 
         [Fact]
+        public async Task TestRegisterKeyDisabled()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/key");
+            request.Content = new StringContent(@"{""key"": ""testkey""}", Encoding.UTF8, JsonMediaType);
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        // Disabled until we re-enable the endpoint
+        // [Fact]
         public async Task TestRegisterKey()
         {
             // GET, not supported

--- a/MorphicServer/AuthEndpoint.cs
+++ b/MorphicServer/AuthEndpoint.cs
@@ -87,7 +87,9 @@ namespace MorphicServer
     }
 
     /// <summary>Authenticate with a key</summary>
-    [Path("/v1/auth/key")]
+    // Disabling until we have a legitimate use case.  Not removing because we expect
+    // to re-enable at some point down the line for something like a USB stick login.
+    // [Path("/v1/auth/key")]
     public class AuthKeyEndpoint: AuthEndpoint<AuthKeyRequest>
     {
         public override async Task<User?> AuthenticatedUser(AuthKeyRequest request)

--- a/MorphicServer/RegisterEndpoint.cs
+++ b/MorphicServer/RegisterEndpoint.cs
@@ -152,7 +152,9 @@ namespace MorphicServer
     }
 
     /// <summary>Create a new user with a username</summary>
-    [Path("/v1/register/key")]
+    // Disabling until we have a legitimate use case.  Not removing because we expect
+    // to re-enable at some point down the line for something like a USB stick login.
+    // [Path("/v1/register/key")]
     public class RegisterKeyEndpoint: RegisterEndpoint<KeyCredential>
     {
         [Method]


### PR DESCRIPTION
No need to have the open until we actually need them.  Keeping the code so
it can be re-enabled when we have a need.