### PR TITLE
add created and updated fields to all Records

### DIFF
--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -121,6 +121,17 @@ namespace MorphicServer
         /// </remarks>
         public async Task<bool> Save<T>(T obj, Session? session = null) where T: Record
         {
+            if (obj.Created == default)
+            {
+                var now = DateTime.UtcNow;
+                obj.Created = now;
+                obj.Updated = now;
+            }
+            else
+            {
+                obj.Updated = DateTime.UtcNow;
+            }
+
             if (CollectionByType[typeof(T)] is IMongoCollection<T> collection)
             {
                 var options = new ReplaceOptions();

--- a/MorphicServer/Record.cs
+++ b/MorphicServer/Record.cs
@@ -35,5 +35,9 @@ namespace MorphicServer
         [BsonId]
         [JsonPropertyName("id")]
         public string Id { get; set; } = "";
+        [JsonIgnoreAttribute]
+        public DateTime Created { get; set; }
+        [JsonIgnoreAttribute]
+        public DateTime Updated { get; set; }
     }
 }


### PR DESCRIPTION
I've definitely appreciated these fields in the past. Incredibly helpful in troubleshooting, if nothing else.
Note that if we used a default mongo ObjectId instead of our own UID for the _id field, it would include a 'created' part in the binary blob. I actually recommend we go to the ObjectId partly because of this (it also makes sorting and indexing faster because it's not a string!). Also the ObjectId is smaller (12 bytes) than a string Guid.