### PR TITLE
Make DB Creation/update happen every time

### DIFF
--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -211,7 +211,6 @@ namespace MorphicServer
         public void InitializeDatabase()
         {
             var stopWatch = Stopwatch.StartNew();
-            //CreateCollectionIfNotExists<DatabaseInfo>();
             _morphic.DropCollection("DatabaseInfo"); // doesn't fail
             
             // TODO: Deal with multi-server database update/upgrade
@@ -285,17 +284,6 @@ namespace MorphicServer
                 _morphic.DatabaseNamespace,
                 collection.CollectionNamespace,
                 indexName);
-        }
-
-        /// <summary>A record of the database initialization</summary>
-        /// <remarks>
-        /// The <code>Version</code> field can be used to perform upgrades to the database as needed.
-        /// </remarks>
-        class DatabaseInfo
-        {
-            [BsonId]
-            public string Id { get; set; } = "0";
-            public int Version { get; set; } = 0;
         }
 
         /// <summary>A database transaction session</summary>

--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -25,15 +25,15 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Text.Json;
 using MongoDB.Driver;
 using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Clusters;
 using Serilog;
-using Serilog.Context;
 
 namespace MorphicServer
 {
@@ -53,6 +53,12 @@ namespace MorphicServer
     /// <summary>A connection to the Morphic database</summary>
     public class Database
     {
+        /// <summary>The MongoDB client connection</summary>
+        private readonly MongoClient _client;
+
+        /// <summary>The Morphic Database</summary>
+        private readonly IMongoDatabase _morphic;
+        
         /// <summary>Create a database using the given settings</summary>
         /// <remarks>
         /// Since the database is registered as a service, it is constructed by the service system.
@@ -60,40 +66,28 @@ namespace MorphicServer
         /// </remarks>
         public Database(DatabaseSettings settings)
         {
-            Client = new MongoClient(settings.ConnectionString);
-            Morphic = Client.GetDatabase(settings.DatabaseName);
+            _client = new MongoClient(settings.ConnectionString);
+            _morphic = _client.GetDatabase(settings.DatabaseName);
 
-            using (LogContext.PushProperty("DBSettings", Client.Settings.ToString()))
-            using (LogContext.PushProperty("DBName", settings.DatabaseName))
-            {
-                Log.Logger.Information("Opened DB");
-            }
+            Log.Logger.Information("Opened DB {Database}: {ConnectionSettings}",
+                settings.DatabaseName, _client.Settings.ToString());
 
-            CollectionByType[typeof(Preferences)] = Morphic.GetCollection<Preferences>("Preferences");
-            CollectionByType[typeof(User)] = Morphic.GetCollection<User>("User");
+            CollectionByType[typeof(Preferences)] = _morphic.GetCollection<Preferences>("Preferences");
+            CollectionByType[typeof(User)] = _morphic.GetCollection<User>("User");
             CollectionByType[typeof(UsernameCredential)] =
-                Morphic.GetCollection<UsernameCredential>("UsernameCredential");
-            CollectionByType[typeof(KeyCredential)] = Morphic.GetCollection<KeyCredential>("KeyCredential");
-            CollectionByType[typeof(AuthToken)] = Morphic.GetCollection<AuthToken>("AuthToken");
+                _morphic.GetCollection<UsernameCredential>("UsernameCredential");
+            CollectionByType[typeof(KeyCredential)] = _morphic.GetCollection<KeyCredential>("KeyCredential");
+            CollectionByType[typeof(AuthToken)] = _morphic.GetCollection<AuthToken>("AuthToken");
             CollectionByType[typeof(BadPasswordLockout)] =
-                Morphic.GetCollection<BadPasswordLockout>("BadPasswordLockout");
+                _morphic.GetCollection<BadPasswordLockout>("BadPasswordLockout");
         }
-
-        /// <summary>The MongoDB client connection</summary>
-        private MongoClient Client;
-
-        /// <summary>The Morphic Database</summary>
-        private IMongoDatabase Morphic;
 
         public void DeleteDatabase()
         {
-            Client.DropDatabase(Morphic.DatabaseNamespace.DatabaseName);
+            _client.DropDatabase(_morphic.DatabaseNamespace.DatabaseName);
         }
 
-        public bool IsClusterConnected
-        {
-            get { return Client.Cluster.Description.State == ClusterState.Connected; }
-        }
+        public bool IsClusterConnected => _client.Cluster.Description.State == ClusterState.Connected;
 
         /// <summary>The MongoDB collections within the database</summary>
         private Dictionary<Type, object> CollectionByType = new Dictionary<Type, object>();
@@ -182,15 +176,15 @@ namespace MorphicServer
             return false;
         }
 
-        /// <summary>Run async operations within a transaction, using a lamba to specify the operations</summary>
+        /// <summary>Run async operations within a transaction, using a lambda to specify the operations</summary>
         /// <remarks>
         /// For most operations that require transactions, a better option is to use the <code>[Method(RunInTransaction=True)]</code>
-        /// attribute, which ensures that any operations, incluing <code>LoadResource</code> are run in the transaction.
+        /// attribute, which ensures that any operations, including <code>LoadResource</code> are run in the transaction.
         /// </remarks>
         public async Task<bool> WithTransaction(Func<Session, Task> operations,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
-            using (var session = await Client.StartSessionAsync(cancellationToken: cancellationToken))
+            using (var session = await _client.StartSessionAsync(cancellationToken: cancellationToken))
             {
                 var options = new TransactionOptions(
                     readPreference: ReadPreference.Primary,
@@ -212,47 +206,85 @@ namespace MorphicServer
 
         /// <summary>Do a one-time database setup or upgrade</summary>
         /// <remarks>
-        /// Creates collections and indexes, and keeps a record of initilization in the <code>DatabaseInfo</code> collection.
+        /// Creates collections and indexes.
         /// </remarks>
-        public void InitializeDatabaseIfNeeded()
+        public void InitializeDatabase()
         {
-            // FIXME: If multiple servers are spun up at the same time, we could have a situation where each tries to initialize or
-            // upgrade the database.  We need some kind of locking system, or this initialization/upgrade code should move to a
-            // script that gets run prior to spinning up instances.
-            var collection = Morphic.GetCollection<DatabaseInfo>("DatabaseInfo");
-            var info = collection.FindSync(info => info.Id == "0").FirstOrDefault();
-            if (info == null)
-            {
-                Morphic.CreateCollection("Preferences");
-
-                Morphic.CreateCollection("User");
-                var users = Morphic.GetCollection<User>("User");
-                users.Indexes.CreateOne(new CreateIndexModel<User>(
-                    Builders<User>.IndexKeys.Hashed(t => t.EmailHash)));
-
-                Morphic.CreateCollection("UsernameCredential");
-                Morphic.CreateCollection("KeyCredential");
-
-                Morphic.CreateCollection("AuthToken");
-                var authTokens = Morphic.GetCollection<AuthToken>("AuthToken");
-                var options = new CreateIndexOptions();
-                options.ExpireAfter = TimeSpan.Zero;
-
-                authTokens.Indexes.CreateOne(new CreateIndexModel<AuthToken>(
+            var stopWatch = Stopwatch.StartNew();
+            //CreateCollectionIfNotExists<DatabaseInfo>();
+            _morphic.DropCollection("DatabaseInfo"); // doesn't fail
+            
+            // TODO: Deal with multi-server database update/upgrade
+            // If multiple servers are spun up at the same time, we could have a situation where each
+            // tries to initialize or upgrade the database.  We need some kind of locking system, or
+            // this initialization/upgrade code should move to a script that gets run prior to spinning
+            // up instances.
+            CreateCollectionIfNotExists<Preferences>();
+            var user = CreateCollectionIfNotExists<User>();
+            CreateOrUpdateIndexOrFail(user,
+                new CreateIndexModel<User>(Builders<User>.IndexKeys.Hashed(t => t.EmailHash)));
+            CreateCollectionIfNotExists<UsernameCredential>();
+            CreateCollectionIfNotExists<KeyCredential>();
+            var authToken = CreateCollectionIfNotExists<AuthToken>();
+            var options = new CreateIndexOptions();
+            options.ExpireAfter = TimeSpan.Zero;
+            CreateOrUpdateIndexOrFail(authToken,
+                new CreateIndexModel<AuthToken>(
                     Builders<AuthToken>.IndexKeys.Ascending(t => t.ExpiresAt), options));
+            var badPasswordLockout = CreateCollectionIfNotExists<BadPasswordLockout>();
+            options = new CreateIndexOptions();
+            options.ExpireAfter = TimeSpan.Zero;
+            CreateOrUpdateIndexOrFail(badPasswordLockout,
+                new CreateIndexModel<BadPasswordLockout>(
+                    Builders<BadPasswordLockout>.IndexKeys.Ascending(t => t.ExpiresAt), options));
+            stopWatch.Stop();
+            Log.Logger.Information("Database create/update took {TotalElapsedSeconds}secs",
+                stopWatch.Elapsed.TotalSeconds);
+        }
 
-                Morphic.CreateCollection("BadPasswordLockout");
-                var badPasswordLockout = Morphic.GetCollection<BadPasswordLockout>("BadPasswordLockout");
-                options = new CreateIndexOptions();
-                options.ExpireAfter = TimeSpan.Zero;
-                badPasswordLockout.Indexes.CreateOne(
-                    new CreateIndexModel<BadPasswordLockout>(
-                        Builders<BadPasswordLockout>.IndexKeys.Ascending(t => t.ExpiresAt), options));
-
-                info = new DatabaseInfo();
-                info.Version = 1;
-                collection.InsertOne(info);
+        private IMongoCollection<T> CreateCollectionIfNotExists<T>()
+        {
+            var collName = typeof(T).Name;
+            try
+            {
+                _morphic.CreateCollection(collName);
+                Log.Logger.Debug("Created Collection {Database}.{Collection}", _morphic.DatabaseNamespace, collName);
             }
+            catch (MongoCommandException e)
+            {
+                if (e.CodeName != "NamespaceExists")
+                    throw;
+                Log.Logger.Debug("Collection {Database}.{Collection} existed already (no error)", _morphic.DatabaseNamespace,collName);
+            }
+
+            return _morphic.GetCollection<T>(collName);
+        }
+
+        /// <summary>
+        /// Wrap MongoCollection.Indexes.CreateOne so that we get some logging and consistent behavior.
+        /// 
+        /// CreateOne() will do nothing if the index already exists with the same options. It will fail
+        /// if the index can not be updated (different options).
+        /// 
+        /// For our purposes, we will let it throw the exception with the understanding that developers
+        /// catch this error during development or test, and deal with it accordingly.
+        /// 
+        /// Cases we need to manually deal with (or find an automated migration solution):
+        /// 1. Need to drop a index that is no longer needed
+        /// 2. Need to 'change an index' which is really a 'drop and create' operation. Perhaps we need
+        ///    to add such a function later.
+        /// </summary>
+        /// <param name="collection">The collection</param>
+        /// <param name="index"></param>
+        /// <typeparam name="T">The Collection Type</typeparam>
+        private void CreateOrUpdateIndexOrFail<T>(IMongoCollection<T> collection, CreateIndexModel<T> index)
+        {
+            var indexName = collection.Indexes.CreateOne(index);
+            Log.Logger.Debug(
+                "Created/updated index {DBname}.{Collection}:{IndexName}",
+                _morphic.DatabaseNamespace,
+                collection.CollectionNamespace,
+                indexName);
         }
 
         /// <summary>A record of the database initialization</summary>
@@ -261,7 +293,8 @@ namespace MorphicServer
         /// </remarks>
         class DatabaseInfo
         {
-            [BsonId] public string Id { get; set; } = "0";
+            [BsonId]
+            public string Id { get; set; } = "0";
             public int Version { get; set; } = 0;
         }
 

--- a/MorphicServer/KeyStorage.cs
+++ b/MorphicServer/KeyStorage.cs
@@ -33,13 +33,13 @@ namespace MorphicServer
         private const string EncryptionKeyPrimary = "MORPHIC_ENC_KEY_PRIMARY";
         private const string EncryptionKeyRolloverPrefix = "MORPHIC_ENC_KEY_ROLLOVER_";
 
-        private static List<KeyInfo>? _keyArray;
+        private static List<KeyInfo>? keyArray;
         
         public static KeyInfo GetKey(string keyName)
         {
             LoadKeysFromEnvIfNeeded();
-            if (_keyArray == null) throw new KeysNotInitialized();
-            var key = _keyArray.FirstOrDefault(k => k.KeyName == keyName);
+            if (keyArray == null) throw new KeysNotInitialized();
+            var key = keyArray.FirstOrDefault(k => k.KeyName == keyName);
             if (key == null) throw new KeyNotFoundException(keyName);
             return key;
         }
@@ -47,8 +47,8 @@ namespace MorphicServer
         public static KeyInfo GetPrimary()
         {
             LoadKeysFromEnvIfNeeded();
-            if (_keyArray == null) throw new KeysNotInitialized();
-            var key = _keyArray.FirstOrDefault(k => k.IsPrimary);
+            if (keyArray == null) throw new KeysNotInitialized();
+            var key = keyArray.FirstOrDefault(k => k.IsPrimary);
             if (key == null) throw new KeyNotFoundException("PRIMARY");
             return key;
         }
@@ -58,12 +58,12 @@ namespace MorphicServer
         /// </summary>
         public static void ClearKeys()
         {
-            _keyArray = null; // Do I need to dispose this?
+            keyArray = null; // Do I need to dispose this?
         }
         
         public static void LoadKeysFromEnvIfNeeded()
         {
-            if (_keyArray == null)
+            if (keyArray == null)
             {
                 var myKeyArray = new List<KeyInfo>();
 
@@ -95,8 +95,8 @@ namespace MorphicServer
                     }
                     myKeyArray.Add(key);
                 }
-                _keyArray = myKeyArray;
-                Log.Logger.Debug($"Loaded {_keyArray.Count} keys");
+                keyArray = myKeyArray;
+                Log.Logger.Debug($"Loaded {keyArray.Count} keys");
             }
         }
 

--- a/MorphicServer/Startup.cs
+++ b/MorphicServer/Startup.cs
@@ -56,7 +56,7 @@ namespace MorphicServer
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, Database database)
         {
-            database.InitializeDatabaseIfNeeded();
+            database.InitializeDatabase();
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
We can now safely (and quickly, and across multiple instances) create collections (in fact you don't need to create collections at all; they will be auto-created on use) and create Indexes (will fail if the index is different, in which case a drop/create is required; should be caught and handled during development anyway).

I've removed the DatabaseInfo, since the 'shape' of the collection depends on each collection, so in the future I will try to find/implement some per-collection migration mechanism.
I've also cleaned up some naming as recommended by my IDE and so forth.