### PR TITLE
Fix compiler warning

### DIFF
--- a/MorphicServer/NonNullableExceptionJsonConverter.cs
+++ b/MorphicServer/NonNullableExceptionJsonConverter.cs
@@ -146,7 +146,7 @@ namespace MorphicServer
             public void CheckForNull(T instance)
             {
                 var required = new List<string>();
-                var type = instance!.GetType();
+                Type? type = instance!.GetType();
                 while (type != null)
                 {
                     foreach (var propertyInfo in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))


### PR DESCRIPTION
Warning is about assigning null to a non-nullable Type.

```  NonNullableExceptionJsonConverter.cs(166, 28): [CS8600] Converting null literal or possible null value to non-nullable type.```

We're checking for null on type anyway, so we're treating it as nullable. Make it so.