### PR TITLE
Change Password endpoint

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -669,6 +669,12 @@ for additional security.
       <td>Required</td>
     </tr>
     <tr>
+      <th><code>delete_existing_tokens</code></th>
+      <td>Delete any existing Auth Tokens</td>
+      <td><code>Boolean</code></td>
+      <td>Optional</td>
+    </tr>
+    <tr>
       <th colspan="4"><code>200</code> Response Body</th>
     </tr>
     <tr>

--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -12,6 +12,7 @@ Endpoints
 * [User Data](#section-user-data)
   * [`/v1/users/{id}`](#endpoint-user)
   * [`/v1/users/{uid}/preferences/{id}`](#endpoint-preferences)
+  * [`/v1/users/{id}/changePassword`](#endpoint-changepassword)
 
 
 <a name="section-user-registration"></a>User Registration
@@ -496,7 +497,7 @@ Save the user object for the given `id`
   </tbody>
 </table>
 
-<a name="endpoint-user"></a>/v1/users/{uid}/preferences/{id}
+<a name="endpoint-preferences"></a>/v1/users/{uid}/preferences/{id}
 ------------------
 
 A preference id can be found in the `preferences_id` property of a user object.
@@ -625,6 +626,70 @@ Save the user object for the given `id`
     </tr>
     <tr>
       <td colspan="4">Empty indicates invalid preferences id</td>
+    </tr>
+  </tbody>
+</table>
+
+<a name="endpoint-changepassword"></a>/v1/user/{id}/changePassword
+------------------
+
+### POST
+
+Change the password of an authenticated user. Providing the old password is required
+for additional security.
+
+<table>
+  <tbody>
+    <tr>
+      <th colspan="4">Headers</th>
+    </tr>
+    <tr>
+      <th><code>Content-Type</code></th>
+      <td colspan="2"><code>application/json; charset=utf-8</code></td>
+      <td>Required</td>
+    </tr>
+    <tr>
+      <th><code>Authorization</code></th>
+      <td colspan="2"><code>"Bearer "</code> + Token string obtained from<code>/auth/username</code> or <code>/auth/key</code></td>
+      <td>Required</td>
+    </tr>
+    <tr>
+      <th colspan="4">Request Body</th>
+    </tr>
+    <tr>
+      <th><code>existing_password</code></th>
+      <td>The existing password</td>
+      <td><code>String</code></td>
+      <td>Required</td>
+    </tr>
+    <tr>
+      <th><code>new_password</code></th>
+      <td>The new password to set</td>
+      <td><code>String</code></td>
+      <td>Required</td>
+    </tr>
+    <tr>
+      <th colspan="4"><code>200</code> Response Body</th>
+    </tr>
+    <tr>
+      <th colspan="4"><code>400</code> Response Body</th>
+    </tr>
+    <tr>
+      <th rowspan="4"><code>error</code></th>
+      <td>Missing required fields</td>
+      <td colspan="2"><code>"missing_required"</code></td>
+    </tr>
+    <tr>
+      <td>Username already exists</td>
+      <td colspan="2"><code>"existing_username"</code></td>
+    </tr>
+    <tr>
+      <td>Invalid credentials</td>
+      <td colspan="2"><code>"invalid_credentials"</code></td>
+    </tr>
+    <tr>
+      <td>Rate limit exceeded</td>
+      <td colspan="2"><code>"rate_limited"</code></td>
     </tr>
   </tbody>
 </table>

--- a/MorphicServer.Tests/BadPasswordLockoutTests.cs
+++ b/MorphicServer.Tests/BadPasswordLockoutTests.cs
@@ -51,7 +51,7 @@ namespace MorphicServer.Tests
             Assert.Equal(1, bpl.Count);
             Assert.Null(await BadPasswordLockout.UserLockedOut(Database, userInfo1.Id));
 
-            lockedOut = await BadPasswordLockout.BadAuthAttempt(this.Database, userInfo1.Id);
+            lockedOut = await BadPasswordLockout.BadAuthAttempt(Database, userInfo1.Id);
             Assert.False(lockedOut);
             
             bpl = await Database.Get<BadPasswordLockout>(userInfo1.Id);
@@ -61,7 +61,7 @@ namespace MorphicServer.Tests
             Assert.Equal(2, bpl.Count);
             Assert.Null(await BadPasswordLockout.UserLockedOut(Database, userInfo1.Id));
 
-            lockedOut = await BadPasswordLockout.BadAuthAttempt(this.Database, userInfo1.Id);
+            lockedOut = await BadPasswordLockout.BadAuthAttempt(Database, userInfo1.Id);
             Assert.False(lockedOut);
             
             bpl = await Database.Get<BadPasswordLockout>(userInfo1.Id);
@@ -71,7 +71,7 @@ namespace MorphicServer.Tests
             Assert.Equal(3, bpl.Count);
             Assert.Null(await BadPasswordLockout.UserLockedOut(Database, userInfo1.Id));
 
-            lockedOut = await BadPasswordLockout.BadAuthAttempt(this.Database, userInfo1.Id);
+            lockedOut = await BadPasswordLockout.BadAuthAttempt(Database, userInfo1.Id);
             Assert.False(lockedOut);
             
             bpl = await Database.Get<BadPasswordLockout>(userInfo1.Id);
@@ -81,7 +81,7 @@ namespace MorphicServer.Tests
             Assert.Equal(4, bpl.Count);
             Assert.Null(await BadPasswordLockout.UserLockedOut(Database, userInfo1.Id));
 
-            lockedOut = await BadPasswordLockout.BadAuthAttempt(this.Database, userInfo1.Id);
+            lockedOut = await BadPasswordLockout.BadAuthAttempt(Database, userInfo1.Id);
             Assert.True(lockedOut);
             
             bpl = await Database.Get<BadPasswordLockout>(userInfo1.Id);

--- a/MorphicServer.Tests/ChangePasswordEndpointTests.cs
+++ b/MorphicServer.Tests/ChangePasswordEndpointTests.cs
@@ -68,6 +68,28 @@ namespace MorphicServer.Tests
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
             response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            
+            // GET, Change again with delete-tokens
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password+"12345");
+            content.Add("new_password", userInfo1.Password);
+            content.Add("delete_existing_tokens", true);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // GET, token was deleted. Get 401
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", userInfo1.Password+"12345");
+            content.Add("delete_existing_tokens", true);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
     }
 }

--- a/MorphicServer.Tests/ChangePasswordEndpointTests.cs
+++ b/MorphicServer.Tests/ChangePasswordEndpointTests.cs
@@ -20,7 +20,7 @@ namespace MorphicServer.Tests
             var userInfo2 = await CreateTestUser();
             
             // GET, Unknown user
-            var request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}12334/changePassword");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}12334/password");
             var content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password);
             content.Add("new_password", userInfo1.Password+"12345");
@@ -30,7 +30,7 @@ namespace MorphicServer.Tests
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
             // GET, Wrong user
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo2.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo2.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password);
             content.Add("new_password", userInfo1.Password+"12345");
@@ -40,7 +40,7 @@ namespace MorphicServer.Tests
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
             // GET, right user user, missing fields
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("new_password", userInfo1.Password+"12345");
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
@@ -50,7 +50,7 @@ namespace MorphicServer.Tests
             var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"existing_password"});
             
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password+"12345");
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
@@ -60,7 +60,7 @@ namespace MorphicServer.Tests
             assertMissingRequired(error, new List<string> {"new_password"});
 
             // GET, Success
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password);
             content.Add("new_password", userInfo1.Password+"12345");
@@ -70,7 +70,7 @@ namespace MorphicServer.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             
             // GET, Change again with delete-tokens
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password+"12345");
             content.Add("new_password", userInfo1.Password);
@@ -81,7 +81,7 @@ namespace MorphicServer.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // GET, token was deleted. Get 401
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password);
             content.Add("new_password", userInfo1.Password+"12345");
@@ -112,7 +112,7 @@ namespace MorphicServer.Tests
             Assert.False(lockedOut);
             
             // GET, Success; not locked out
-            var request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             var content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password);
             content.Add("new_password", userInfo1.Password+"12345");
@@ -125,7 +125,7 @@ namespace MorphicServer.Tests
             Assert.True(lockedOut);
             
             // GET, Success; not locked out
-            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();
             content.Add("existing_password", userInfo1.Password+"12345");
             content.Add("new_password", userInfo1.Password);

--- a/MorphicServer.Tests/ChangePasswordEndpointTests.cs
+++ b/MorphicServer.Tests/ChangePasswordEndpointTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MorphicServer.Tests
+{
+    public class ChangePasswordEndpointTests : EndpointTests
+    {
+        [Fact]
+        public async Task TestGet()
+        {
+            var userInfo1 = await CreateTestUser();
+            var userInfo2 = await CreateTestUser();
+            
+            // GET, Unknown user
+            var request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}12334/changePassword");
+            var content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", userInfo1.Password+"12345");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+            // GET, Wrong user
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo2.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", userInfo1.Password+"12345");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+            // GET, right user user, missing fields
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("new_password", userInfo1.Password+"12345");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            JsonElement property;
+            var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            Assert.True(error.TryGetProperty("details", out property));
+            Assert.Equal(JsonValueKind.Object, property.ValueKind);
+            Assert.True(property.TryGetProperty("required", out property));
+            Assert.Equal(JsonValueKind.Array, property.ValueKind);
+            Assert.Equal(1, property.GetArrayLength());
+            Assert.Equal("existing_password", property[0].GetString());
+            
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password+"12345");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            Assert.True(error.TryGetProperty("details", out property));
+            Assert.Equal(JsonValueKind.Object, property.ValueKind);
+            Assert.True(property.TryGetProperty("required", out property));
+            Assert.Equal(JsonValueKind.Array, property.ValueKind);
+            Assert.Equal(1, property.GetArrayLength());
+            Assert.Equal("new_password", property[0].GetString());
+
+            // GET, Success
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", userInfo1.Password+"12345");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}

--- a/MorphicServer.Tests/ChangePasswordEndpointTests.cs
+++ b/MorphicServer.Tests/ChangePasswordEndpointTests.cs
@@ -48,12 +48,7 @@ namespace MorphicServer.Tests
             response = await Client.SendAsync(request);
             JsonElement property;
             var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
-            Assert.True(error.TryGetProperty("details", out property));
-            Assert.Equal(JsonValueKind.Object, property.ValueKind);
-            Assert.True(property.TryGetProperty("required", out property));
-            Assert.Equal(JsonValueKind.Array, property.ValueKind);
-            Assert.Equal(1, property.GetArrayLength());
-            Assert.Equal("existing_password", property[0].GetString());
+            assertMissingRequired(error, new List<string> {"existing_password"});
             
             request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");
             content = new Dictionary<string, object>();
@@ -62,12 +57,7 @@ namespace MorphicServer.Tests
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
             response = await Client.SendAsync(request);
             error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
-            Assert.True(error.TryGetProperty("details", out property));
-            Assert.Equal(JsonValueKind.Object, property.ValueKind);
-            Assert.True(property.TryGetProperty("required", out property));
-            Assert.Equal(JsonValueKind.Array, property.ValueKind);
-            Assert.Equal(1, property.GetArrayLength());
-            Assert.Equal("new_password", property[0].GetString());
+            assertMissingRequired(error, new List<string> {"new_password"});
 
             // GET, Success
             request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/changePassword");

--- a/MorphicServer.Tests/EndpointTests.cs
+++ b/MorphicServer.Tests/EndpointTests.cs
@@ -28,6 +28,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -167,6 +168,28 @@ namespace MorphicServer.Tests
             Assert.True(element.TryGetProperty("details", out property));
             // don't check value here. Caller can check the details of details.
             return element;
+        }
+        
+        public void assertMissingRequired(JsonElement error, List<string> missing, bool strict=true)
+        {
+            JsonElement property;
+            Assert.True(error.TryGetProperty("details", out property));
+            Assert.Equal(JsonValueKind.Object, property.ValueKind);
+            Assert.True(property.TryGetProperty("required", out property));
+            Assert.Equal(JsonValueKind.Array, property.ValueKind);
+            List<string> propertyArray = new List<string>();
+            for (int i = 0; i < property.GetArrayLength(); i++)
+            {
+                propertyArray.Add(property[i].GetString());
+            }
+            if (strict)
+            {
+                Assert.True(Enumerable.SequenceEqual(propertyArray.OrderBy(t => t), missing.OrderBy(t => t)));
+            }
+            else
+            {
+                Assert.True(propertyArray.Intersect(missing).Equals(missing));
+            }
         }
     }
 }

--- a/MorphicServer/BadPasswordLockout.cs
+++ b/MorphicServer/BadPasswordLockout.cs
@@ -74,9 +74,20 @@ namespace MorphicServer
         public static async Task<DateTime?> UserLockedOut(Database db, string userId)
         {
             var badPasswordLockout = await db.Get<BadPasswordLockout>(userId);
-            if (badPasswordLockout != null && badPasswordLockout.ShouldBlockLogin())
+            if (badPasswordLockout != null)
             {
-                return badPasswordLockout.ExpiresAt;
+                return badPasswordLockout.UserLockedOut();
+            }
+
+            // user is not locked out
+            return null;
+        }
+
+        public DateTime? UserLockedOut()
+        {
+            if (ShouldBlockLogin())
+            {
+                return ExpiresAt;
             }
 
             // user is not locked out

--- a/MorphicServer/ChangePasswordEndpoint.cs
+++ b/MorphicServer/ChangePasswordEndpoint.cs
@@ -58,7 +58,7 @@ namespace MorphicServer
             var db = Context.GetDatabase();
             var user = await db.UserForUsernameCredential(usernameCredentials, request.ExistingPassword);
             usernameCredentials.SetPassword(request.NewPassword);
-            if (request.DeleteExistingTokens == true)
+            if (request.DeleteExistingTokens)
             {
                 await Delete<AuthToken>(token => token.UserId == user.Id);
             }

--- a/MorphicServer/ChangePasswordEndpoint.cs
+++ b/MorphicServer/ChangePasswordEndpoint.cs
@@ -44,30 +44,31 @@ namespace MorphicServer
                 throw new HttpError(HttpStatusCode.Forbidden);
             }
             
-            _usernameCredentials = await Load<UsernameCredential>(u => u.UserId == authenticatedUser.Id);
+            usernameCredentials = await Load<UsernameCredential>(u => u.UserId == authenticatedUser.Id);
             Log.Logger.Debug("Loaded user credential for {UserId}", authenticatedUser.Id);
         }
 
         /// <summary>The UsernameCredential data populated by <code>LoadResource()</code></summary>
-        private UsernameCredential _usernameCredentials = new UsernameCredential();
+        private UsernameCredential usernameCredentials = new UsernameCredential();
 
         [Method]
         public async Task Post()
         {
             var request = await Request.ReadJson<ChangePasswordRequest>();
             var db = Context.GetDatabase();
-            await db.UserForUsernameCredential(_usernameCredentials, request.ExistingPassword);
-            _usernameCredentials.SetPassword(request.NewPassword);
-            await Save(_usernameCredentials);
+            await db.UserForUsernameCredential(usernameCredentials, request.ExistingPassword);
+            usernameCredentials.SetPassword(request.NewPassword);
+            // TODO Should this invalidate any existing tokens? If yes, should we return a new token here?
+            await Save(usernameCredentials);
         }
 
         /// <summary>Model for change password requests</summary>
         public class ChangePasswordRequest
         {
             [JsonPropertyName("existing_password")]
-            public string ExistingPassword { get; set; } = "";
+            public string ExistingPassword { get; set; } = null!;
             [JsonPropertyName("new_password")]
-            public string NewPassword { get; set; } = "";
+            public string NewPassword { get; set; } = null!;
         }
     }
 }

--- a/MorphicServer/ChangePasswordEndpoint.cs
+++ b/MorphicServer/ChangePasswordEndpoint.cs
@@ -29,7 +29,7 @@ using Serilog;
 
 namespace MorphicServer
 {
-    [Path("/v1/users/{userid}/changePassword")]
+    [Path("/v1/users/{userid}/password")]
     public class ChangePasswordEndpoint : Endpoint
     {
         /// <summary>The user id to use, populated from the request URL</summary>
@@ -49,7 +49,7 @@ namespace MorphicServer
         }
 
         /// <summary>The UsernameCredential data populated by <code>LoadResource()</code></summary>
-        private UsernameCredential usernameCredentials = new UsernameCredential();
+        private UsernameCredential usernameCredentials = null!;
 
         [Method]
         public async Task Post()
@@ -72,7 +72,6 @@ namespace MorphicServer
             public string ExistingPassword { get; set; } = null!;
             [JsonPropertyName("new_password")]
             public string NewPassword { get; set; } = null!;
-            // TODO For some reason I don't understand this isn't flagged as missing if not present.
             [JsonPropertyName("delete_existing_tokens")]
             public bool DeleteExistingTokens { get; set; } = false;
         }

--- a/MorphicServer/ChangePasswordEndpoint.cs
+++ b/MorphicServer/ChangePasswordEndpoint.cs
@@ -1,0 +1,73 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+using System.Net;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using MorphicServer.Attributes;
+using Serilog;
+
+namespace MorphicServer
+{
+    [Path("/v1/users/{userid}/changePassword")]
+    public class ChangePasswordEndpoint : Endpoint
+    {
+        /// <summary>The user id to use, populated from the request URL</summary>
+        [Parameter]
+        public string UserId = "";
+
+        public override async Task LoadResource()
+        {
+            var authenticatedUser = await RequireUser();
+            if (authenticatedUser.Id != UserId)
+            {
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+            
+            _usernameCredentials = await Load<UsernameCredential>(u => u.UserId == authenticatedUser.Id);
+            Log.Logger.Debug("Loaded user credential for {UserId}", authenticatedUser.Id);
+        }
+
+        /// <summary>The UsernameCredential data populated by <code>LoadResource()</code></summary>
+        private UsernameCredential _usernameCredentials = new UsernameCredential();
+
+        [Method]
+        public async Task Post()
+        {
+            var request = await Request.ReadJson<ChangePasswordRequest>();
+            var db = Context.GetDatabase();
+            await db.UserForUsernameCredential(_usernameCredentials, request.ExistingPassword);
+            _usernameCredentials.SetPassword(request.NewPassword);
+            await Save(_usernameCredentials);
+        }
+
+        /// <summary>Model for change password requests</summary>
+        public class ChangePasswordRequest
+        {
+            [JsonPropertyName("existing_password")]
+            public string ExistingPassword { get; set; } = "";
+            [JsonPropertyName("new_password")]
+            public string NewPassword { get; set; } = "";
+        }
+    }
+}

--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -161,15 +161,20 @@ namespace MorphicServer
         /// </remarks>
         public async Task<bool> Delete<T>(T obj, Session? session = null) where T : Record
         {
+            return await Delete<T>(record => record.Id == obj.Id, session);
+        }
+
+        public async Task<bool> Delete<T>(Expression<Func<T, bool>> filter, Session? session = null) where T : Record
+        {
             if (CollectionByType[typeof(T)] is IMongoCollection<T> collection)
             {
                 if (session != null)
                 {
-                    return (await collection.DeleteOneAsync(session.Handle, record => record.Id == obj.Id))
+                    return (await collection.DeleteOneAsync(session.Handle, filter))
                         .IsAcknowledged;
                 }
 
-                return (await collection.DeleteOneAsync(record => record.Id == obj.Id)).IsAcknowledged;
+                return (await collection.DeleteOneAsync(filter)).IsAcknowledged;
             }
 
             return false;

--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -231,6 +231,11 @@ namespace MorphicServer
                     Builders<User>.IndexKeys.Hashed(t => t.EmailHash)));
 
                 Morphic.CreateCollection("UsernameCredential");
+                var usernameCredentials = Morphic.GetCollection<UsernameCredential>("UsernameCredential");
+                usernameCredentials.Indexes.CreateOne(new CreateIndexModel<UsernameCredential>(
+                    Builders<UsernameCredential>.IndexKeys.Hashed(t => t.UserId)));
+
+
                 Morphic.CreateCollection("KeyCredential");
 
                 Morphic.CreateCollection("AuthToken");

--- a/MorphicServer/Database.cs
+++ b/MorphicServer/Database.cs
@@ -229,8 +229,12 @@ namespace MorphicServer
             CreateOrUpdateIndexOrFail(user,
                 new CreateIndexModel<User>(Builders<User>.IndexKeys.Hashed(t => t.EmailHash)));
             var usernameCredentials = CreateCollectionIfNotExists<UsernameCredential>();
-            usernameCredentials.Indexes.CreateOne(new CreateIndexModel<UsernameCredential>(
-                Builders<UsernameCredential>.IndexKeys.Hashed(t => t.UserId)));
+            // IndexExplanation: When changing a user's password, which lives in the UsernameCredentials collection,
+            // we need to look up the UsernameCredentials by that user's ID, so we can change the password.
+            // See ChangePasswordEndpoint
+            CreateOrUpdateIndexOrFail(usernameCredentials,
+                new CreateIndexModel<UsernameCredential>(
+                    Builders<UsernameCredential>.IndexKeys.Hashed(t => t.UserId)));
 
             CreateCollectionIfNotExists<KeyCredential>();
             var authToken = CreateCollectionIfNotExists<AuthToken>();

--- a/MorphicServer/Endpoint.cs
+++ b/MorphicServer/Endpoint.cs
@@ -33,6 +33,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using MorphicServer.Attributes;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Prometheus;
@@ -264,8 +265,13 @@ namespace MorphicServer
 
         public async Task<T> Load<T>(string id) where T: Record
         {
+            return await Load<T>(r => r.Id == id);
+        }
+
+        public async Task<T> Load<T>(Expression<Func<T, bool>> filter) where T : Record
+        {
             var db = Context.GetDatabase();
-            T? record = await db.Get<T>(id, ActiveSession);
+            T? record = await db.Get<T>(filter, ActiveSession);
             if (record == null){
                 throw new HttpError(HttpStatusCode.NotFound);
             }

--- a/MorphicServer/Endpoint.cs
+++ b/MorphicServer/Endpoint.cs
@@ -296,6 +296,15 @@ namespace MorphicServer
             }
         }
 
+        public async Task Delete<T>(Expression<Func<T, bool>> filter) where T : Record
+        {
+            var db = Context.GetDatabase();
+            var success = await db.Delete<T>(filter, ActiveSession);
+            if (!success){
+                throw new HttpError(HttpStatusCode.InternalServerError);
+            }
+        }
+
         /// <summary>Convenience method for serializing an object to JSON as a response</summary>
         public async Task Respond<T>(T obj)
         {

--- a/MorphicServer/RegisterEndpoint.cs
+++ b/MorphicServer/RegisterEndpoint.cs
@@ -90,7 +90,7 @@ namespace MorphicServer
             
             var cred = new UsernameCredential();
             cred.Id = request.Username;
-            cred.SavePassword(request.Password);
+            cred.SetPassword(request.Password);
             
             var user = new User();
             user.Id = Guid.NewGuid().ToString();

--- a/loadTest/morphiclite/__init__.py
+++ b/loadTest/morphiclite/__init__.py
@@ -188,3 +188,11 @@ class Users(AuthedMorphicRequest):
             self.logger.error("returned userId {} doesn't match sent {}", user['user_id'], self.userId)
 
         return user
+
+    def changePassword(self, old_password, new_password):
+        path = self.DefaultUsersUrl.format(userId=self.userId) + "/changePassword"
+        changeRequest = {
+            'existing_password': old_password,
+            'new_password': new_password
+        }
+        self.json_request('POST', path, data_obj=changeRequest)

--- a/loadTest/morphiclite/test.py
+++ b/loadTest/morphiclite/test.py
@@ -40,15 +40,15 @@ def testrunner(args):
                     auth = UserAuth(base_url, logger=logger).doAuth(username, password)
                 logger.debug(json.dumps(auth, indent=4))
 
-                try:
-                    kwargs = {
-                        'url': base_url,
-                        'userId': auth['user']['id'],
-                        'authToken': auth['token'],
-                        'logger': logger
-                    }
+                users_kwargs = {
+                    'url': base_url,
+                    'userId': auth['user']['id'],
+                    'authToken': auth['token'],
+                    'logger': logger
+                }
 
-                    user = Users(**kwargs).get()
+                try:
+                    user = Users(**users_kwargs).get()
                     print(user)
                 except Exception as e:
                     print(e)
@@ -61,6 +61,13 @@ def testrunner(args):
                         pass
 
                     try:
+                        Users(**users_kwargs).changePassword(password, password+"123")
+                        auth = UserAuth(base_url, logger=logger).doAuth(username, password+"123")
+                        Users(**users_kwargs).changePassword(password+"123", password)
+                    except Exception as e:
+                        logger.error("Could not change password", e)
+
+                    try:
                         Register(base_url, logger=logger).get()
                     except MorphicLite.MorphicLiteError as e:
                         # this is expected!
@@ -69,14 +76,14 @@ def testrunner(args):
                     else:
                         logger.error("GET Register worked but shouldn't have")
 
-                kwargs = {
+                users_kwargs = {
                     'url': base_url,
                     'userId': auth['user']['id'],
                     'authToken': auth['token'],
                     'pref_id': auth['user']['preferences_id'],
                     'logger': logger
                 }
-                pref_kls = Preferences(**kwargs)
+                pref_kls = Preferences(**users_kwargs)
                 if args.extra_tests:
                     try:
                         pref_kls.post()


### PR DESCRIPTION
User needs to be authenticated (have a token) to call the endpoint, and they have to pass the old password. This prevents someone from somehow hijacking or finding the token somewhere, and then changing the password.
Bad-password-lockout also applies.
Caller may optionally request that all active tokens are deleted, immediately locking out every other user/token (this is good security, but not strictly necessary; up to the discretion of the caller).
Cleaned up some code so that LastAuth is touched only during auth and not during password changing (which uses a common function).