### PR TITLE
password changing and reset fixes

### DIFF
--- a/MorphicServer.Tests/ChangePasswordEndpointTests.cs
+++ b/MorphicServer.Tests/ChangePasswordEndpointTests.cs
@@ -59,6 +59,27 @@ namespace MorphicServer.Tests
             error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"new_password"});
 
+            // Missing password
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", "");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            assertMissingRequired(error, new List<string> {"new_password"});
+
+            // bad password
+            request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
+            content = new Dictionary<string, object>();
+            content.Add("existing_password", userInfo1.Password);
+            content.Add("new_password", "password");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "bad_password");
+
             // GET, Success
             request = new HttpRequestMessage(HttpMethod.Post, $"v1/users/{userInfo1.Id}/password");
             content = new Dictionary<string, object>();

--- a/MorphicServer.Tests/EndpointTests.cs
+++ b/MorphicServer.Tests/EndpointTests.cs
@@ -56,6 +56,8 @@ namespace MorphicServer.Tests
         /// <summary>A reference to the test database</summary>
         protected Database Database;
 
+        protected MorphicSettings MorphicSettings;
+        
         /// <summary>Create a test database, test http server, and client connection to the test server</summary>
         public EndpointTests()
         {
@@ -75,6 +77,7 @@ namespace MorphicServer.Tests
             Server = new TestServer(builder);
             Client = Server.CreateClient();
             Database = Server.Services.GetService(typeof(Database)) as Database;
+            MorphicSettings = Server.Services.GetService(typeof(MorphicSettings)) as MorphicSettings;
         }
 
         /// <summary>Delete the test database after every test case so each test can start fresh</summary>

--- a/MorphicServer.Tests/EndpointTests.cs
+++ b/MorphicServer.Tests/EndpointTests.cs
@@ -88,7 +88,7 @@ namespace MorphicServer.Tests
         }
 
         /// <summary>Create a test user and return an auth token</summary>
-        protected async Task<UserInfo> CreateTestUser(string firstName = "Test", string lastName = "User")
+        protected async Task<UserInfo> CreateTestUser(string firstName = "Test", string lastName = "User", bool verifiedEmail = false)
         {
             ++TestUserCount;
             var content = new Dictionary<string, object>();
@@ -126,6 +126,14 @@ namespace MorphicServer.Tests
             Assert.NotEqual("", property.GetString());
             var preferencesId = property.GetString();
             Assert.False(user.TryGetProperty("EmailVerified", out property));
+
+            if (verifiedEmail)
+            {
+                var dbUser = await Database.Get<User>(id);
+                Assert.NotNull(dbUser);
+                dbUser.EmailVerified = true;
+                await Database.Save(dbUser);
+            }
 
             return new UserInfo()
             {

--- a/MorphicServer.Tests/PasswordResetTests.cs
+++ b/MorphicServer.Tests/PasswordResetTests.cs
@@ -13,7 +13,7 @@ namespace MorphicServer.Tests
         [Fact]
         public async Task ResetPasswordRequestHeaderTests()
         {
-            var userInfo1 = await CreateTestUser();
+            var userInfo1 = await CreateTestUser(verifiedEmail:true);
 
             // Fail: No headers
             var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");

--- a/MorphicServer.Tests/PasswordResetTests.cs
+++ b/MorphicServer.Tests/PasswordResetTests.cs
@@ -60,6 +60,14 @@ namespace MorphicServer.Tests
             var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"email"});
 
+            // Fail: bad email
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            content = new Dictionary<string, object>();
+            content.Add("email", "something");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            response = await Client.SendAsync(request);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "bad_email_address");
+
             // Success
             request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
             content = new Dictionary<string, object>();

--- a/MorphicServer.Tests/PasswordResetTests.cs
+++ b/MorphicServer.Tests/PasswordResetTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MorphicServer.Tests
+{
+    public class PasswordResetTests : EndpointTests
+    {
+        [Fact]
+        public async Task ResetPasswordRequestHeaderTests()
+        {
+            var userInfo1 = await CreateTestUser();
+
+            // Fail: No headers
+            var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            var content = new Dictionary<string, object>();
+            content.Add("email", userInfo1.Email);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            MorphicSettings.ServerUrlPrefix = "";
+            await Assert.ThrowsAsync<Endpoint.NoServerUrlFoundException>(() => Client.SendAsync(request));
+            
+            // Success using x-forwarded headers
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            content = new Dictionary<string, object>();
+            content.Add("email", userInfo1.Email);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            MorphicSettings.ServerUrlPrefix = "";
+            request.Headers.Add("X-Forwarded-Host", new List<string> {"foo"});
+            request.Headers.Add("X-Forwarded-Port", new List<string> {"443"});
+            request.Headers.Add("X-Forwarded-Proto", new List<string> {"https"});
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Success using MorphicSettings.ServerUrlPrefix
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            content = new Dictionary<string, object>();
+            content.Add("email", userInfo1.Email);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            MorphicSettings.ServerUrlPrefix = "http://foo:1234";
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        
+        [Fact]
+        public async Task ResetPasswordRequestWithUser()
+        {
+            var userInfo1 = await CreateTestUser();
+            MorphicSettings.ServerUrlPrefix = "http://foo:1234";
+
+            // Fail: missing email
+            var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            var content = new Dictionary<string, object>();
+            content.Add("email", "");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            var response = await Client.SendAsync(request);
+            var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            assertMissingRequired(error, new List<string> {"email"});
+
+            // Success
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            content = new Dictionary<string, object>();
+            content.Add("email", userInfo1.Email);
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResetPasswordRequestWithoutUser()
+        {
+            // Success
+            var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/request");
+            var content = new Dictionary<string, object>();
+            content.Add("email", "Somerandomemail@example.com");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        
+        [Fact]
+        public async Task ResetPassword()
+        {
+            var userInfo1 = await CreateTestUser();
+            var token = new OneTimeToken(userInfo1.Id);
+            await Database.Save(token);
+            
+            // Fail: missing password
+            var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/{token.GetUnhashedToken()}");
+            var content = new Dictionary<string, object>();
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            var response = await Client.SendAsync(request);
+            var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            assertMissingRequired(error, new List<string> {"new_password"});
+
+            // Fail: crappy passwords
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/{token.GetUnhashedToken()}");
+            content = new Dictionary<string, object>();
+            content.Add("new_password", "password");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            response = await Client.SendAsync(request);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "bad_password");
+
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/{token.GetUnhashedToken()}");
+            content = new Dictionary<string, object>();
+            content.Add("new_password", "");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            response = await Client.SendAsync(request);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
+            
+            // Success
+            request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/{token.GetUnhashedToken()}");
+            content = new Dictionary<string, object>();
+            content.Add("new_password", "something new");
+            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}

--- a/MorphicServer.Tests/PasswordResetTests.cs
+++ b/MorphicServer.Tests/PasswordResetTests.cs
@@ -110,7 +110,8 @@ namespace MorphicServer.Tests
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             response = await Client.SendAsync(request);
             await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
-            
+            assertMissingRequired(error, new List<string> {"new_password"});
+
             // Success
             request = new HttpRequestMessage(HttpMethod.Post, $"/v1/auth/username/password_reset/{token.GetUnhashedToken()}");
             content = new Dictionary<string, object>();

--- a/MorphicServer/AuthUsernamePasswordResetEndpoint.cs
+++ b/MorphicServer/AuthUsernamePasswordResetEndpoint.cs
@@ -161,6 +161,11 @@ namespace MorphicServer
             {
                 throw new HttpError(HttpStatusCode.BadRequest, BadPasswordRequestResponse.MissingRequired);
             }
+
+            if (!User.IsValidEmail(request.Email))
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadPasswordRequestResponse.BadEmailAddress);
+            }
             var db = Context.GetDatabase();
             var hash = User.UserEmailHashCombined(request.Email);
             using (LogContext.PushProperty("EmailHash", hash))
@@ -195,6 +200,7 @@ namespace MorphicServer
         
         public class BadPasswordRequestResponse : BadRequestResponse
         {
+            public static readonly BadPasswordRequestResponse BadEmailAddress = new BadPasswordRequestResponse("bad_email_address");
             public static readonly BadPasswordRequestResponse MissingRequired = new BadPasswordRequestResponse(
                 "missing_required",
                 new Dictionary<string, object>
@@ -202,6 +208,9 @@ namespace MorphicServer
                     {"required", new List<string> { "email" } }
                 });
             public BadPasswordRequestResponse(string error, Dictionary<string, object> details) : base(error, details)
+            {
+            }
+            public BadPasswordRequestResponse(string error) : base(error)
             {
             }
         }

--- a/MorphicServer/AuthUsernamePasswordResetEndpoint.cs
+++ b/MorphicServer/AuthUsernamePasswordResetEndpoint.cs
@@ -176,7 +176,7 @@ namespace MorphicServer
                     if (user.EmailVerified)
                     {
                         Log.Logger.Information("Password reset requested for userId {userId}", user.Id);
-                        BackgroundJob.Enqueue<NewPasswordResetEmail>(x => x.QueueEmail(user.Id,
+                        BackgroundJob.Enqueue<PasswordResetEmail>(x => x.QueueEmail(user.Id,
                             GetControllerPathUrl<AuthUsernamePasswordResetEndpoint>(Request.Headers,
                                 Context.GetMorphicSettings()),
                             Request.ClientIp()));
@@ -184,7 +184,7 @@ namespace MorphicServer
                     else
                     {
                         Log.Logger.Information("Password reset requested for userId {userId}, but email not verified", user.Id);
-                        BackgroundJob.Enqueue<NewEmailNotVerifiedPasswordResetEmail>(x => x.QueueEmail(
+                        BackgroundJob.Enqueue<EmailNotVerifiedPasswordResetEmail>(x => x.QueueEmail(
                             request.Email,
                             Request.ClientIp()));
                     }
@@ -192,7 +192,7 @@ namespace MorphicServer
                 else
                 {
                     Log.Logger.Information("Password reset requested but no email matching");
-                    BackgroundJob.Enqueue<NewNoEmailPasswordResetEmail>(x => x.QueueEmail(
+                    BackgroundJob.Enqueue<UnknownEmailPasswordResetEmail>(x => x.QueueEmail(
                         request.Email,
                         Request.ClientIp()));
                 }

--- a/MorphicServer/ChangePasswordEndpoint.cs
+++ b/MorphicServer/ChangePasswordEndpoint.cs
@@ -57,7 +57,7 @@ namespace MorphicServer
             var request = await Request.ReadJson<ChangePasswordRequest>();
             var db = Context.GetDatabase();
             var user = await db.UserForUsernameCredential(usernameCredentials, request.ExistingPassword);
-            usernameCredentials.SetPassword(request.NewPassword);
+            usernameCredentials.CheckAndSetPassword(request.NewPassword);
             if (request.DeleteExistingTokens)
             {
                 await Delete<AuthToken>(token => token.UserId == user.Id);

--- a/MorphicServer/EmailTemplates.cs
+++ b/MorphicServer/EmailTemplates.cs
@@ -98,9 +98,9 @@ namespace MorphicServer
         {
         }
     }
-    public class NewVerificationEmail : EmailTemplates
+    public class EmailVerificationEmail : EmailTemplates
     {
-        public NewVerificationEmail(EmailSettings settings, ILogger<NewVerificationEmail> logger, Database db) : base(settings, logger, db)
+        public EmailVerificationEmail(EmailSettings settings, ILogger<EmailVerificationEmail> logger, Database db) : base(settings, logger, db)
         {
             EmailMsgTemplate = @"Dear $UserFullName$,
 
@@ -142,9 +142,9 @@ $MorphicUser$ ($MorphicEmail$)";
         }
     }
 
-    public class NewPasswordResetEmail : EmailTemplates
+    public class PasswordResetEmail : EmailTemplates
     {
-        public NewPasswordResetEmail(EmailSettings settings, ILogger<NewVerificationEmail> logger, Database db) : base(settings, logger, db)
+        public PasswordResetEmail(EmailSettings settings, ILogger<EmailVerificationEmail> logger, Database db) : base(settings, logger, db)
         {
             EmailMsgTemplate =
                 @"Dear $UserFullName$,
@@ -188,9 +188,9 @@ $MorphicUser$ ($MorphicEmail$)";
         }
     }
     
-    public class NewNoEmailPasswordResetEmail : EmailTemplates
+    public class UnknownEmailPasswordResetEmail : EmailTemplates
     {
-        public NewNoEmailPasswordResetEmail(EmailSettings settings, ILogger<NewVerificationEmail> logger, Database db) : base(settings, logger, db)
+        public UnknownEmailPasswordResetEmail(EmailSettings settings, ILogger<EmailVerificationEmail> logger, Database db) : base(settings, logger, db)
         {
             EmailMsgTemplate =
                 @"Dear $UserFullName$,
@@ -221,9 +221,9 @@ $MorphicUser$ ($MorphicEmail$)";
         }
     }
     
-    public class NewEmailNotVerifiedPasswordResetEmail : EmailTemplates
+    public class EmailNotVerifiedPasswordResetEmail : EmailTemplates
     {
-        public NewEmailNotVerifiedPasswordResetEmail(EmailSettings settings, ILogger<NewVerificationEmail> logger, Database db) : base(settings, logger, db)
+        public EmailNotVerifiedPasswordResetEmail(EmailSettings settings, ILogger<EmailVerificationEmail> logger, Database db) : base(settings, logger, db)
         {
             EmailMsgTemplate =
                 @"Dear $UserFullName$,

--- a/MorphicServer/RegisterEndpoint.cs
+++ b/MorphicServer/RegisterEndpoint.cs
@@ -81,7 +81,6 @@ namespace MorphicServer
                 throw new HttpError(HttpStatusCode.BadRequest, BadRequestResponseUser.MissingRequired);
             }
 
-            CheckPassword(request.Password);
             await CheckEmail(request.Email);
 
             var existing = await Context.GetDatabase().Get<UsernameCredential>(request.Username, ActiveSession);
@@ -92,7 +91,7 @@ namespace MorphicServer
             
             var cred = new UsernameCredential();
             cred.Id = request.Username;
-            cred.SetPassword(request.Password);
+            cred.CheckAndSetPassword(request.Password);
             
             var user = new User();
             user.Id = Guid.NewGuid().ToString();
@@ -121,31 +120,7 @@ namespace MorphicServer
                 return false;
             }
         }
-
-        private const int MinPasswordLength = 6;
-
-        private static readonly ReadOnlyCollection<string> BadPasswords = new ReadOnlyCollection<string>(
-            new[] {
-                "password",
-                "testing"
-            }
-        );
-
-        private static void CheckPassword(String password)
-        {   
-            if (password.Length < MinPasswordLength)
-            {
-                Log.Logger.Information("SHORT_PASSWORD({username})");
-                throw new HttpError(HttpStatusCode.BadRequest, BadRequestResponseUser.ShortPassword);
-            }
-
-            if (BadPasswords.Contains(password))
-            {
-                Log.Logger.Information("KNOWN_BAD_PASSWORD({username})");
-                throw new HttpError(HttpStatusCode.BadRequest, BadRequestResponseUser.BadPassword);
-            }
-        }
-
+        
         private async Task CheckEmail(String email)
         {
             if (!IsValidEmail(email))
@@ -180,17 +155,6 @@ namespace MorphicServer
             public static readonly BadRequestResponse ExistingEmail = new BadRequestResponseUser("existing_email");
             public static readonly BadRequestResponse MalformedEmail = new BadRequestResponseUser("malformed_email");
             public static readonly BadRequestResponse MissingRequired = new BadRequestResponseUser("missing_required");
-            public static readonly BadRequestResponse ShortPassword = new BadRequestResponseUser(
-                "short_password",
-                new Dictionary<string, object>
-                {
-                    {"minimum_length", MinPasswordLength}
-                });
-            public static readonly BadRequestResponse BadPassword = new BadRequestResponseUser("bad_password");
-
-            public BadRequestResponseUser(string error, Dictionary<string, object> details) : base(error, details)
-            {
-            }
 
             private BadRequestResponseUser(string error) : base(error)
             {

--- a/MorphicServer/RegisterEndpoint.cs
+++ b/MorphicServer/RegisterEndpoint.cs
@@ -100,7 +100,7 @@ namespace MorphicServer
             user.LastName = request.LastName;
 
             await Register(cred, user);
-            BackgroundJob.Enqueue<NewVerificationEmail>(x => x.QueueEmail(
+            BackgroundJob.Enqueue<EmailVerificationEmail>(x => x.QueueEmail(
                 user.Id,
                 GetControllerPathUrl<ValidateEmailEndpoint>(Request.Headers, Context.GetMorphicSettings()),
                 Request.ClientIp()

--- a/MorphicServer/RegisterEndpoint.cs
+++ b/MorphicServer/RegisterEndpoint.cs
@@ -107,23 +107,9 @@ namespace MorphicServer
             ));
         }
 
-        private static bool IsValidEmail(string emailaddress)
-        {
-            try
-            {
-                // ReSharper disable once ObjectCreationAsStatement
-                new MailAddress(emailaddress);
-                return true;
-            }
-            catch (FormatException)
-            {
-                return false;
-            }
-        }
-        
         private async Task CheckEmail(String email)
         {
-            if (!IsValidEmail(email))
+            if (!User.IsValidEmail(email))
             {
                 Log.Logger.Information("MALFORMED_EMAIL");
                 throw new HttpError(HttpStatusCode.BadRequest, BadRequestResponseUser.MalformedEmail);

--- a/MorphicServer/SendPendingEmails.cs
+++ b/MorphicServer/SendPendingEmails.cs
@@ -88,6 +88,7 @@ namespace MorphicServer
             EmailValidation,
             PasswordResetExistingUser,
             PasswordResetNoUser,
+            PasswordResetEmailNotVerified
         }
         
 

--- a/MorphicServer/User.cs
+++ b/MorphicServer/User.cs
@@ -22,6 +22,7 @@
 // * Consumer Electronics Association Foundation
 
 using System;
+using System.Net.Mail;
 using System.Text.Json.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using Serilog;
@@ -132,6 +133,20 @@ namespace MorphicServer
             }
 
             return plainText;
+        }
+        
+        public static bool IsValidEmail(string emailaddress)
+        {
+            try
+            {
+                // ReSharper disable once ObjectCreationAsStatement
+                new MailAddress(emailaddress);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Check the password, like in registration. Moved the password-checking to where it belongs: into the class that owns the password (UsernameCredential).
Check the email format, like in registration.
Disallow password resets for email addresses that were not previously validated.
Renamed the email templates