### PR TITLE
Some bugfixes, reorg and 'request new email validation email' endpoints

### DIFF
--- a/Morphic.Security/HashedData.cs
+++ b/Morphic.Security/HashedData.cs
@@ -86,7 +86,7 @@ namespace Morphic.Security
             this.hash = hash;
         }
 
-        protected static HashedData FromCombinedString(String hashedCombinedString)
+        public static HashedData FromCombinedString(String hashedCombinedString)
         {
             var parts = hashedCombinedString.Split(":");
             if (parts.Length != 4)

--- a/Morphic.Server.Tests/AuthEndpointTests.cs
+++ b/Morphic.Server.Tests/AuthEndpointTests.cs
@@ -132,7 +132,7 @@ namespace Morphic.Server.Tests
         }
 
         // Disabled until we re-enabled the endpoint
-        // [Fact]
+        [Fact (Skip = "We're not using the Key endpoints today")]
         public async Task TestKey()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, "/v1/register/key");

--- a/Morphic.Server.Tests/EndpointRequestTests.cs
+++ b/Morphic.Server.Tests/EndpointRequestTests.cs
@@ -30,12 +30,12 @@ using System.Text.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Hangfire;
 using Xunit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Serilog;
-using Serilog.Formatting.Compact;
 
 namespace Morphic.Server.Tests
 {
@@ -62,6 +62,8 @@ namespace Morphic.Server.Tests
         protected Database Database;
 
         protected MorphicSettings MorphicSettings;
+
+        protected MockBackgroundJobClient JobClient;
         
         /// <summary>Create a test database, test http server, and client connection to the test server</summary>
         public EndpointRequestTests()
@@ -81,6 +83,8 @@ namespace Morphic.Server.Tests
             Database = Server.Services.GetService(typeof(Database)) as Database;
             MorphicSettings = Server.Services.GetService(typeof(MorphicSettings)) as MorphicSettings;
             Debug.Assert(MorphicSettings != null, nameof(MorphicSettings) + " != null");
+            JobClient = Server.Services.GetService((typeof(IBackgroundJobClient))) as MockBackgroundJobClient;
+            Debug.Assert(JobClient != null, nameof(JobClient) + " != null");
         }
 
         /// <summary>Delete the test database after every test case so each test can start fresh</summary>
@@ -88,6 +92,7 @@ namespace Morphic.Server.Tests
         {
             Database.DeleteDatabase();
             if (Startup.DotNetRuntimeCollector != null) Startup.DotNetRuntimeCollector.Dispose();
+            JobClient.Job = null;
         }
 
         /// <summary>Create a test user and return an auth token</summary>

--- a/Morphic.Server.Tests/MockRecaptcha.cs
+++ b/Morphic.Server.Tests/MockRecaptcha.cs
@@ -22,6 +22,7 @@
 // * Consumer Electronics Association Foundation
 
 using System.Threading.Tasks;
+using Morphic.Server.Auth;
 
 namespace Morphic.Server.Tests
 {

--- a/Morphic.Server.Tests/MockRecaptcha.cs
+++ b/Morphic.Server.Tests/MockRecaptcha.cs
@@ -28,6 +28,8 @@ namespace Morphic.Server.Tests
 {
     public class MockRecaptcha : IRecaptcha
     {
+        public static string GoodResponseString = "goodResponse";
+        
         public string Key
         {
             get
@@ -38,7 +40,8 @@ namespace Morphic.Server.Tests
         
         public Task<bool> ReCaptchaPassed(string action, string gRecaptchaResponse)
         {
-            return Task.FromResult(true);
+            // if GoodResponseString, return true. Else false.
+            return Task.FromResult(gRecaptchaResponse == GoodResponseString);
         }
     }
 }

--- a/Morphic.Server.Tests/MockStartup.cs
+++ b/Morphic.Server.Tests/MockStartup.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Morphic.Security;
+using Morphic.Server.Auth;
 using Serilog;
 
 namespace Morphic.Server.Tests

--- a/Morphic.Server.Tests/RegisterEndpointTests.cs
+++ b/Morphic.Server.Tests/RegisterEndpointTests.cs
@@ -270,7 +270,7 @@ namespace Morphic.Server.Tests
         }
 
         // Disabled until we re-enable the endpoint
-        // [Fact]
+        [Fact (Skip = "We're not using the Key endpoints today")]
         public async Task TestRegisterKey()
         {
             // GET, not supported

--- a/Morphic.Server.Tests/RegisterEndpointTests.cs
+++ b/Morphic.Server.Tests/RegisterEndpointTests.cs
@@ -37,6 +37,8 @@ namespace Morphic.Server.Tests
         [Fact]
         public async Task TestRegisterUsername()
         {
+            JobClient.Job = null;
+
             // GET, not supported
             var path = "/v1/register/username";
             var request = new HttpRequestMessage(HttpMethod.Get, path);
@@ -165,6 +167,8 @@ namespace Morphic.Server.Tests
             response = await Client.SendAsync(request);
             await assertJsonError(response, HttpStatusCode.BadRequest, "malformed_email");
 
+            Assert.Null(JobClient.Job);
+
             // POST, success
             request = new HttpRequestMessage(HttpMethod.Post, path);
             content = new Dictionary<string, object>();
@@ -196,7 +200,9 @@ namespace Morphic.Server.Tests
             Assert.Equal(JsonValueKind.Null, property.ValueKind);
             Assert.True(user.TryGetProperty("last_name", out property));
             Assert.Equal(JsonValueKind.Null, property.ValueKind);
-
+            Assert.NotNull(JobClient.Job);
+            Assert.Equal("Morphic.Server.Auth.EmailVerificationEmail", JobClient.Job.Type.FullName);
+            
             // POST, success with first/last name
             request = new HttpRequestMessage(HttpMethod.Post, path);
             content = new Dictionary<string, object>();

--- a/Morphic.Server.Tests/VerifyEmailEndpointTests.cs
+++ b/Morphic.Server.Tests/VerifyEmailEndpointTests.cs
@@ -34,7 +34,7 @@ namespace Morphic.Server.Tests
     using Users;
     using Auth;
 
-    public class ValidateEmailEndpointTests : EndpointRequestTests
+    public class VerifyEmailEndpointTests : EndpointRequestTests
     {
 
         [Fact]

--- a/Morphic.Server.Tests/VerifyEmailRequestTests.cs
+++ b/Morphic.Server.Tests/VerifyEmailRequestTests.cs
@@ -1,0 +1,60 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Morphic.Server.Tests
+{
+    public class VerifyEmailRequestTests : EndpointRequestTests
+    {
+        [Fact]
+        public async Task TestGet()
+        {
+            var userInfo1 = await CreateTestUser();
+
+            var path = "/v1/users/{0}/verify_email";
+            // GET, unauth
+            var request = new HttpRequestMessage(HttpMethod.Get, string.Format(path, userInfo1.Id));
+            var response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+
+            // POST, unauth
+            request = new HttpRequestMessage(HttpMethod.Post, string.Format(path, userInfo1.Id));
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            
+            // POST, auth
+            JobClient.Job = null;
+            request = new HttpRequestMessage(HttpMethod.Post, string.Format(path, userInfo1.Id));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userInfo1.AuthToken);
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(JobClient.Job);
+            Assert.Equal("Morphic.Server.Auth.EmailVerificationEmail", JobClient.Job.Type.FullName);
+        }
+    }
+}

--- a/Morphic.Server.Tests/VerifyEmailRequestUnauthTests.cs
+++ b/Morphic.Server.Tests/VerifyEmailRequestUnauthTests.cs
@@ -27,23 +27,18 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Morphic.Server.Users;
 using Xunit;
 
 namespace Morphic.Server.Tests
 {
-
-    using Auth;
-
-    public class PasswordResetTests : EndpointRequestTests
+    public class VerifyEmailRequestUnauthTests : EndpointRequestTests
     {
-        
         [Fact]
-        public async Task ResetPasswordRequestWithUser()
+        public async Task VerifyEmailRequestUnauth()
         {
             var userInfo1 = await CreateTestUser();
             MorphicSettings.FrontEndServerUrlPrefix = "http://foo:1234";
-            var path = "/v1/auth/username/password_reset/request";
+            var path = "/v1/user/verify_email_request";
             JobClient.Job = null;
 
             // Fail: missing email and recaptcha
@@ -53,7 +48,8 @@ namespace Morphic.Server.Tests
             var response = await Client.SendAsync(request);
             var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"email", "g_recaptcha_response"});
-
+            Assert.Null(JobClient.Job);
+            
             // Fail: missing email
             request = new HttpRequestMessage(HttpMethod.Post, path);
             content = new Dictionary<string, object>();
@@ -62,6 +58,7 @@ namespace Morphic.Server.Tests
             response = await Client.SendAsync(request);
             error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"email"});
+            Assert.Null(JobClient.Job);
 
             // Fail: blank email
             request = new HttpRequestMessage(HttpMethod.Post, path);
@@ -72,6 +69,7 @@ namespace Morphic.Server.Tests
             response = await Client.SendAsync(request);
             error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
             assertMissingRequired(error, new List<string> {"email"});
+            Assert.Null(JobClient.Job);
 
             // Fail: bad email
             request = new HttpRequestMessage(HttpMethod.Post, path);
@@ -81,6 +79,7 @@ namespace Morphic.Server.Tests
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             response = await Client.SendAsync(request);
             await assertJsonError(response, HttpStatusCode.BadRequest, "bad_email_address");
+            Assert.Null(JobClient.Job);
 
             // bad captcha response
             request = new HttpRequestMessage(HttpMethod.Post, path);
@@ -90,12 +89,9 @@ namespace Morphic.Server.Tests
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             response = await Client.SendAsync(request);
             await assertJsonError(response, HttpStatusCode.BadRequest, "bad_recaptcha");
-            
-            // no emails sent so far!
             Assert.Null(JobClient.Job);
 
             // Success
-            JobClient.Job = null;
             request = new HttpRequestMessage(HttpMethod.Post, path);
             content = new Dictionary<string, object>();
             content.Add("email", userInfo1.Email);
@@ -104,81 +100,7 @@ namespace Morphic.Server.Tests
             response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(JobClient.Job);
-            Assert.Equal("Morphic.Server.Auth.EmailNotVerifiedPasswordResetEmail", JobClient.Job.Type.FullName);
-            
-            // success with verified email
-            var user = await Database.Get<User>(userInfo1.Id);
-            user.EmailVerified = true;
-            await Database.Save(user);
-            
-            // Success
-            JobClient.Job = null;
-            request = new HttpRequestMessage(HttpMethod.Post, path);
-            content = new Dictionary<string, object>();
-            content.Add("email", userInfo1.Email);
-            content.Add("g_recaptcha_response", MockRecaptcha.GoodResponseString);
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.NotNull(JobClient.Job);
-            Assert.Equal("Morphic.Server.Auth.PasswordResetEmail", JobClient.Job.Type.FullName);
-        }
-
-        [Fact]
-        public async Task ResetPasswordRequestWithoutUser()
-        {
-            var path = "/v1/auth/username/password_reset/request";
-
-            // Success
-            var request = new HttpRequestMessage(HttpMethod.Post, path);
-            var content = new Dictionary<string, object>();
-            content.Add("email", "Somerandomemail@example.com");
-            content.Add("g_recaptcha_response", MockRecaptcha.GoodResponseString);
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            var response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("Morphic.Server.Auth.UnknownEmailPasswordResetEmail", JobClient.Job.Type.FullName);
-        }
-        
-        [Fact]
-        public async Task ResetPassword()
-        {
-            var userInfo1 = await CreateTestUser();
-            var token = new OneTimeToken(userInfo1.Id);
-            await Database.Save(token);
-            var pathPrefix = "/v1/auth/username/password_reset";
-            
-            // Fail: missing password
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{pathPrefix}/{token.GetUnhashedToken()}");
-            var content = new Dictionary<string, object>();
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            var response = await Client.SendAsync(request);
-            var error = await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
-            assertMissingRequired(error, new List<string> {"new_password"});
-            
-            // Fail: crappy passwords
-            request = new HttpRequestMessage(HttpMethod.Post, $"{pathPrefix}/{token.GetUnhashedToken()}");
-            content = new Dictionary<string, object>();
-            content.Add("new_password", "password");
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            response = await Client.SendAsync(request);
-            await assertJsonError(response, HttpStatusCode.BadRequest, "bad_password");
-
-            request = new HttpRequestMessage(HttpMethod.Post, $"{pathPrefix}/{token.GetUnhashedToken()}");
-            content = new Dictionary<string, object>();
-            content.Add("new_password", "");
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            response = await Client.SendAsync(request);
-            await assertJsonError(response, HttpStatusCode.BadRequest, "missing_required");
-            assertMissingRequired(error, new List<string> {"new_password"});
-
-            // Success
-            request = new HttpRequestMessage(HttpMethod.Post, $"{pathPrefix}/{token.GetUnhashedToken()}");
-            content = new Dictionary<string, object>();
-            content.Add("new_password", "something new");
-            request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
-            response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Morphic.Server.Auth.EmailVerificationEmail", JobClient.Job.Type.FullName);
         }
     }
 }

--- a/Morphic.Server/Auth/AuthUsernamePasswordResetEndpoint.cs
+++ b/Morphic.Server/Auth/AuthUsernamePasswordResetEndpoint.cs
@@ -228,7 +228,6 @@ namespace Morphic.Server.Auth
             [JsonPropertyName("email")]
             public string Email { get; set; } = null!;
             
-            // TODO Not sure if we can use underscores here. Depends on whether the caller reformats the data.
             [JsonPropertyName("g_recaptcha_response")]
             public string GRecaptchaResponse { get; set; } = null!;
         }

--- a/Morphic.Server/Auth/Recaptcha.cs
+++ b/Morphic.Server/Auth/Recaptcha.cs
@@ -31,9 +31,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
-using Serilog;
 
-namespace Morphic.Server
+namespace Morphic.Server.Auth
 {
     public interface IRecaptcha
     {
@@ -95,7 +94,7 @@ namespace Morphic.Server
                 var result = JsonSerializer.Deserialize<RecaptchaResult>(json);
                 if (!result.Success)
                 {
-                    logger.LogWarning("ReCaptcha result success = false ({0})", result.ErrorCodes);
+                    logger.LogWarning("ReCaptcha result success = false ({0})", result.ErrorCodes.ToString());
                     return false;
                 }
                 if (result.Action != action)

--- a/Morphic.Server/Auth/ValidateEmailEndpoint.cs
+++ b/Morphic.Server/Auth/ValidateEmailEndpoint.cs
@@ -21,7 +21,6 @@
 // * Adobe Foundation
 // * Consumer Electronics Association Foundation
 
-using System;
 using System.Net;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -85,9 +84,16 @@ namespace Morphic.Server.Auth
             }
         }
         
-        /// <summary>Fetch the user</summary>
+        /// <summary>Mark the email verified</summary>
         [Method]
         public async Task Get()
+        {
+            // backwards compatibility for a release or two.
+            await Post();
+        }
+
+        [Method]
+        public async Task Post()
         {
             user.EmailVerified = true;
             await Save(user);

--- a/Morphic.Server/Auth/VerifyEmailEndpoint.cs
+++ b/Morphic.Server/Auth/VerifyEmailEndpoint.cs
@@ -34,9 +34,9 @@ namespace Morphic.Server.Auth
     using Users;
 
     [Path("/v1/users/{userId}/verify_email/{oneTimeToken}")]
-    public class ValidateEmailEndpoint : Endpoint
+    public class VerifyEmailEndpoint : Endpoint
     {
-        public ValidateEmailEndpoint(IHttpContextAccessor contextAccessor, ILogger<ValidateEmailEndpoint> logger): base(contextAccessor, logger)
+        public VerifyEmailEndpoint(IHttpContextAccessor contextAccessor, ILogger<VerifyEmailEndpoint> logger): base(contextAccessor, logger)
         {
             AddAllowedOrigin(settings.FrontEndServerUri);
         }

--- a/Morphic.Server/Auth/VerifyEmailEndpoint.cs
+++ b/Morphic.Server/Auth/VerifyEmailEndpoint.cs
@@ -98,7 +98,6 @@ namespace Morphic.Server.Auth
             user.EmailVerified = true;
             await Save(user);
             await OneTimeToken.Invalidate(Context.GetDatabase());
-            // TODO Need to respond with a nicer webpage than ""
             await Respond(new SuccessResponse("email_verified"));
         }
 

--- a/Morphic.Server/Auth/VerifyEmailRequestUnauthEndpoint.cs
+++ b/Morphic.Server/Auth/VerifyEmailRequestUnauthEndpoint.cs
@@ -1,0 +1,130 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+using System.Collections.Generic;
+using System.Net;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Hangfire;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Morphic.Server.Auth
+{
+    using Http;
+    using Users;
+    
+    [Path("/v1/user/verify_email_request")]
+    public class VerifyEmailRequestUnauthEndpoint : Endpoint
+    {
+        private IBackgroundJobClient jobClient;
+        private IRecaptcha recaptcha;
+
+        public VerifyEmailRequestUnauthEndpoint(
+            IHttpContextAccessor contextAccessor,
+            ILogger<VerifyEmailRequestUnauthEndpoint> logger,
+            IRecaptcha recaptcha,
+            IBackgroundJobClient jobClient)
+            : base(contextAccessor, logger)
+        {
+            AddAllowedOrigin(settings.FrontEndServerUri);
+            this.recaptcha = recaptcha;
+            this.jobClient = jobClient;
+        }
+        
+        /// <summary>Resend the welcome email.</summary>
+        [Method]
+        public async Task Post()
+        {
+            var request = await Request.ReadJson<VerifyEmailRequestRequest>();
+            if (request.GRecaptchaResponse == "")
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadVerificationRequestResponse.MissingRequired(new List<string> { "g_captcha_response" }));
+            }
+            if (!await recaptcha.ReCaptchaPassed("verifyemailrequest", request.GRecaptchaResponse))
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadVerificationRequestResponse.BadReCaptcha);
+            }
+            if (request.Email == "")
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadVerificationRequestResponse.MissingRequired(new List<string> { "email" }));
+            }
+
+            if (!User.IsValidEmail(request.Email))
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadVerificationRequestResponse.BadEmailAddress);
+            }
+            var db = Context.GetDatabase();
+            var user = await db.UserForEmail(request.Email, ActiveSession);
+            if (user == null)
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, BadVerificationRequestResponse.UserNotFound);
+            }
+
+            var hash = user.Email.Hash!.ToCombinedString();
+            logger.LogInformation("Verify Email requested for userId {userId} {EmailHash}",
+                user.Id, hash);
+            jobClient.Enqueue<EmailVerificationEmail>(x => x.SendEmail(
+                user.Id,
+                Request.ClientIp()
+            ));
+        }
+        
+        /// <summary>
+        /// Model the Verify-Email-Request Request
+        /// </summary>
+        public class VerifyEmailRequestRequest
+        {
+            [JsonPropertyName("email")]
+            public string Email { get; set; } = null!;
+            
+            [JsonPropertyName("g_recaptcha_response")]
+            public string GRecaptchaResponse { get; set; } = null!;
+        }
+
+        public class BadVerificationRequestResponse : BadRequestResponse
+        {
+            public static readonly BadVerificationRequestResponse UserNotFound = new BadVerificationRequestResponse("invalid_user");
+            public static readonly BadVerificationRequestResponse BadReCaptcha = new BadVerificationRequestResponse("bad_recaptcha");
+            public static readonly BadVerificationRequestResponse BadEmailAddress = new BadVerificationRequestResponse("bad_email_address");
+
+            public static BadVerificationRequestResponse MissingRequired(List<string> missing)
+            {
+                return new BadVerificationRequestResponse(
+                    "missing_required",
+                    new Dictionary<string, object>
+                    {
+                        {"required", missing}
+                    });
+            }
+
+            public BadVerificationRequestResponse(string error, Dictionary<string, object> details) : base(error, details)
+            {
+            }
+
+            public BadVerificationRequestResponse(string error) : base(error)
+            {
+            }
+        }
+    }
+}

--- a/Morphic.Server/Startup.cs
+++ b/Morphic.Server/Startup.cs
@@ -40,7 +40,6 @@ using Prometheus;
 using Prometheus.DotNetRuntime;
 using Serilog;
 using Morphic.Security;
-using Morphic.Server.Auth;
 
 namespace Morphic.Server
 {
@@ -48,7 +47,8 @@ namespace Morphic.Server
     using Db;
     using Email;
     using Http;
-
+    using Auth;
+    
     public class Startup
     {
         public Startup(IConfiguration configuration)

--- a/Morphic.Server/Startup.cs
+++ b/Morphic.Server/Startup.cs
@@ -40,6 +40,7 @@ using Prometheus;
 using Prometheus.DotNetRuntime;
 using Serilog;
 using Morphic.Security;
+using Morphic.Server.Auth;
 
 namespace Morphic.Server
 {

--- a/Morphic.Server/Users/VerifyEmailRequestEndpoint.cs
+++ b/Morphic.Server/Users/VerifyEmailRequestEndpoint.cs
@@ -1,0 +1,84 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+using System.Net;
+using System.Threading.Tasks;
+using Hangfire;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Morphic.Server.Users
+{
+    using Http;
+    using Auth;
+
+    [Path("/v1/users/{userId}/verify_email")]
+    public class VerifyEmailRequestEndpoint : Endpoint
+    {
+        private IBackgroundJobClient jobClient;
+
+        public VerifyEmailRequestEndpoint(
+            IHttpContextAccessor contextAccessor,
+            ILogger<VerifyEmailRequestEndpoint> logger,
+            IBackgroundJobClient jobClient)
+            : base(contextAccessor, logger)
+        {
+            this.jobClient = jobClient;
+        }
+
+        /// <summary>
+        /// The userid to use, populated from the request URL. Unused, since we get it from the token,
+        /// but it makes for a more coherent API.
+        /// </summary>
+        [Parameter]
+        public string UserId = "";
+
+        /// <summary>The user data populated by <code>LoadResource()</code></summary>
+        public User User = new User();
+
+        public override async Task LoadResource()
+        {
+            var authenticatedUser = await RequireUser();
+            if (authenticatedUser.Id != UserId)
+            {
+                logger.LogInformation("{AuthenticatedUserUid} may not request user {UserUid}",
+                    authenticatedUser.Id, UserId);
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+            User = await Load<User>(UserId);
+        }
+
+        /// <summary>Resend the welcome email.</summary>
+        [Method]
+        public async Task Post()
+        {
+            await Task.Run(() =>
+            {
+                jobClient.Enqueue<EmailVerificationEmail>(x => x.SendEmail(
+                    User.Id,
+                    Request.ClientIp()
+                ));
+            });
+        }
+    }
+}

--- a/Morphic.Server/Users/VerifyEmailRequestEndpoint.cs
+++ b/Morphic.Server/Users/VerifyEmailRequestEndpoint.cs
@@ -32,6 +32,10 @@ namespace Morphic.Server.Users
     using Http;
     using Auth;
 
+    /// <summary>
+    /// Endpoint used to request a new welcome/email validation email, in case the user
+    /// somehow didn't get the one from the registration.
+    /// </summary>
     [Path("/v1/users/{userId}/verify_email")]
     public class VerifyEmailRequestEndpoint : Endpoint
     {
@@ -47,8 +51,7 @@ namespace Morphic.Server.Users
         }
 
         /// <summary>
-        /// The userid to use, populated from the request URL. Unused, since we get it from the token,
-        /// but it makes for a more coherent API.
+        /// The userid to use, populated from the request URL.
         /// </summary>
         [Parameter]
         public string UserId = "";


### PR DESCRIPTION
Sorry! Once I got started fixing some smaller things and adding unit tests, I got a bit carried away. Consequently the PR is a bit broader than just adding some new endpoints.

- Moved Recaptcha to auth. Http would also make sense, I guess.
- Added auth'd and unauth'd (recaptcha) endpoints to request the email validation email to be resent. We can pick one and delete the other? Or use both?
- Added encryption tests
- Added some checks to make sure (via the MockBackgroundJob) that the right email was indeed sent.