### PR TITLE
make the user first and last name encrypted

### DIFF
--- a/Morphic.Server.Tests/UserEndpointTests.cs
+++ b/Morphic.Server.Tests/UserEndpointTests.cs
@@ -33,7 +33,7 @@ using System.Text;
 
 namespace Morphic.Server.Tests
 {
-
+    using Security;
     using Users;
 
     public class UserEndpointTests : EndpointRequestTests
@@ -204,15 +204,19 @@ namespace Morphic.Server.Tests
             user.LastName = null;
             Assert.Equal("", user.FullName);
 
-            user.FirstName = "foo";
+            user.FirstName = new EncryptedString();
+            user.FirstName.PlainText = "foo";
             Assert.Equal("foo", user.FullName);
 
             user.FirstName = null;
-            user.LastName = "bar";
+            user.LastName = new EncryptedString();
+            user.LastName.PlainText = "bar";
             Assert.Equal("bar", user.FullName);
 
-            user.FirstName = "foo";
-            user.LastName = "bar";
+            user.FirstName = new EncryptedString();
+            user.LastName = new EncryptedString();
+            user.FirstName.PlainText = "foo";
+            user.LastName.PlainText = "bar";
             Assert.Equal("foo bar", user.FullName);
         }
 

--- a/Morphic.Server/Auth/RegisterEndpoint.cs
+++ b/Morphic.Server/Auth/RegisterEndpoint.cs
@@ -31,7 +31,7 @@ using Hangfire;
 
 namespace Morphic.Server.Auth
 {
-
+    using Security;
     using Http;
     using Users;
 
@@ -105,9 +105,16 @@ namespace Morphic.Server.Auth
             var user = new User();
             var cred = new UsernameCredential(user.Id, request.Username, request.Password);
             user.Email.PlainText = request.Email;
-            user.FirstName = request.FirstName;
-            user.LastName = request.LastName;
-
+            if (!string.IsNullOrEmpty(request.FirstName))
+            {
+                user.FirstName = new EncryptedString();
+                user.FirstName.PlainText = request.FirstName;
+            }
+            if (!string.IsNullOrEmpty(request.LastName))
+            {
+                user.LastName = new EncryptedString();
+                user.LastName.PlainText = request.LastName;
+            }
             await Register(cred, user);
             jobClient.Enqueue<EmailVerificationEmail>(x => x.SendEmail(
                 user.Id,
@@ -185,8 +192,16 @@ namespace Morphic.Server.Auth
             cred.Id = request.Key;
             var user = new User();
             user.EmailVerified = false;
-            user.FirstName = request.FirstName;
-            user.LastName = request.LastName;
+            if (!string.IsNullOrEmpty(request.FirstName))
+            {
+                user.FirstName = new EncryptedString();
+                user.FirstName.PlainText = request.FirstName;
+            }
+            if (!string.IsNullOrEmpty(request.LastName))
+            {
+                user.LastName = new EncryptedString();
+                user.LastName.PlainText = request.LastName;
+            }
             await Register(cred, user);
         }
 

--- a/Morphic.Server/Community/CommunitiesEndpoint.cs
+++ b/Morphic.Server/Community/CommunitiesEndpoint.cs
@@ -82,8 +82,8 @@ namespace Morphic.Server.Community
                 State = MemberState.Active,
                 CreatedAt = DateTime.Now
             };
-            member.FirstName.PlainText = User.FirstName;
-            member.LastName.PlainText = User.LastName;
+            member.FirstName.PlainText = User.FirstName?.PlainText;
+            member.LastName.PlainText = User.LastName?.PlainText;
             await db.Save(member);
 
             await Respond(new CommunityPutResponse()

--- a/Morphic.Server/Users/User.cs
+++ b/Morphic.Server/Users/User.cs
@@ -26,20 +26,22 @@ using System.Net.Mail;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using MongoDB.Bson.Serialization.Attributes;
-using Morphic.Security;
 
 namespace Morphic.Server.Users
 {
-
+    using Json;
+    using Security;
     using Db;
     
     public class User: Record
     {
         
         [JsonPropertyName("first_name")]
-        public string? FirstName { get; set; }
+        [JsonInclude]
+        public EncryptedString? FirstName { get; set; }
         [JsonPropertyName("last_name")]
-        public string? LastName { get; set; }
+        [JsonInclude]
+        public EncryptedString? LastName { get; set; }
         [JsonPropertyName("preferences_id")]
         public string? PreferencesId { get; set; }
         [JsonPropertyName("email")]
@@ -79,18 +81,18 @@ namespace Morphic.Server.Users
             {
                 string fullName = "";
 
-                if (!string.IsNullOrEmpty(FirstName) || !string.IsNullOrEmpty(LastName))
+                if (!string.IsNullOrEmpty(FirstName?.PlainText) || !string.IsNullOrEmpty(LastName?.PlainText))
                 {
-                    if (!string.IsNullOrEmpty(FirstName)) fullName = FirstName!;
-                    if (!string.IsNullOrEmpty(LastName))
+                    if (!string.IsNullOrEmpty(FirstName?.PlainText)) fullName = FirstName.PlainText;
+                    if (!string.IsNullOrEmpty(LastName?.PlainText))
                     {
                         if (fullName == "")
                         {
-                            fullName = LastName;
+                            fullName = LastName.PlainText;
                         }
                         else
                         {
-                            fullName += " " + LastName;
+                            fullName += " " + LastName.PlainText;
                         }
                     }
                 }

--- a/Morphic.Server/Users/UserEndpoint.cs
+++ b/Morphic.Server/Users/UserEndpoint.cs
@@ -79,8 +79,8 @@ namespace Morphic.Server.Users
             var db = Context.GetDatabase();
             var members = await db.GetEnumerable<Community.Member>(m => m.UserId == User.Id);
             foreach (var member in members){
-                member.FirstName.PlainText = User.FirstName;
-                member.LastName.PlainText = User.LastName;
+                member.FirstName.PlainText = User.FirstName?.PlainText;
+                member.LastName.PlainText = User.LastName?.PlainText;
                 await db.Save(member);
             }
         }


### PR DESCRIPTION
In dev, no one is using first and last name.
Stage has 1 entry, also doesn't use first and last name.
Prod has no entries at all.
So we can push this soon without a migration